### PR TITLE
include an actual screenshot of their project as the first thing on their landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Duck-UI is a web-based interface for interacting with DuckDB, a high-performance analytical database system. This project leverages DuckDB's WebAssembly (WASM) capabilities to provide a seamless and efficient user experience directly in the browser.
 
+![Public Demo](./docs/static/img/sql-editor.png)
+
 # [Official Docs](https://duckui.com?utm_source=github&utm_medium=readme) 🚀
 #  [Demo](https://demo.duckui.com?utm_source=github&utm_medium=readme) 💻
 


### PR DESCRIPTION
I noticed feedback on HN that this project could use a screenshot.
- https://news.ycombinator.com/item?id=43347755

I found a screenshot in the docs that approximates the content at https://demo.duckui.com.

Link that existing screenshot as a pragmatic smaller change than adding a screenshot script.

---
Note: This commit was generated and submitted by an agentic system operated by PeoplesGrocers LLC.

Our system identified this issue during our own development work. If you have concerns about this fix or need human input, reply with @GrocerPublishAgent human and an engineer will review when available during US business hours.