### PR TITLE
fix(connections): auto-connect the ENV-configured external connection on startup

### DIFF
--- a/src/store/slices/__tests__/duckdbSlice.envConnect.test.ts
+++ b/src/store/slices/__tests__/duckdbSlice.envConnect.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Regression test for the ENV-configured external connection never being
+ * auto-connected on startup: `initialize()` used to check
+ * `initialConnections[0]` to decide whether to call `setCurrentConnection`,
+ * but the WASM provider is always pushed first, so that check could never be
+ * true and the branch was dead code.
+ */
+
+vi.mock("@/lib/appConfig", () => ({
+  loadAppConfig: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/services/persistence/repositories/settingsRepository", () => ({
+  getSetting: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { warning: vi.fn(), success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+const { mockConnection, mockLocalSession } = vi.hoisted(() => {
+  const connection = { query: vi.fn().mockResolvedValue(undefined) };
+  return {
+    mockConnection: connection,
+    mockLocalSession: { kind: "local", local: { db: {}, connection } },
+  };
+});
+
+vi.mock("@/services/engine", () => ({
+  builtInWasmConnection: vi.fn().mockReturnValue({ id: "WASM", config: { kind: "wasm" } }),
+  closeAllSessions: vi.fn().mockResolvedValue(undefined),
+  openSession: vi.fn().mockResolvedValue(mockLocalSession),
+  requireLocalDuckSession: vi.fn().mockReturnValue(mockLocalSession),
+  WASM_CONNECTION_ID: "WASM",
+}));
+
+vi.mock("../connectionSlice", () => ({
+  localHandles: vi.fn().mockReturnValue({ db: {}, connection: mockConnection }),
+  toCurrentConnection: vi.fn((provider) => provider),
+}));
+
+import { createDuckdbSlice } from "../duckdbSlice";
+
+// duckdbSlice reads `window.env` and `self.crossOriginIsolated` — this test
+// runs in vitest's node environment, which has neither, so stub the minimal
+// shape it needs. (Bun's own runtime aliases `self` to `globalThis`, which
+// masked the missing stub locally; plain Node does not.)
+(globalThis as { window?: { env?: Window["env"] } }).window ??= {};
+(globalThis as { self?: typeof globalThis }).self ??= globalThis;
+
+describe("duckdbSlice.initialize — ENV connection auto-connect", () => {
+  beforeEach(() => {
+    window.env = {
+      DUCK_UI_EXTERNAL_CONNECTION_NAME: "prod",
+      DUCK_UI_EXTERNAL_HOST: "https://duck.example.com",
+      DUCK_UI_EXTERNAL_PORT: "9999",
+      DUCK_UI_EXTERNAL_USER: "",
+      DUCK_UI_EXTERNAL_PASS: "",
+      DUCK_UI_EXTERNAL_API_KEY: "key-abc",
+      DUCK_UI_EXTERNAL_DATABASE_NAME: "analytics",
+      DUCK_UI_ALLOW_UNSIGNED_EXTENSIONS: false,
+    };
+  });
+
+  it("auto-connects to the ENV connection instead of staying on WASM", async () => {
+    const setCurrentConnection = vi.fn().mockResolvedValue(undefined);
+    const fetchDatabasesAndTablesInfo = vi.fn().mockResolvedValue(undefined);
+
+    let state: Record<string, unknown> = { currentProfileId: null };
+    const set = (partial: unknown) => {
+      const next = typeof partial === "function" ? partial(state) : partial;
+      state = { ...state, ...next };
+    };
+    const get = () => ({ ...state, setCurrentConnection, fetchDatabasesAndTablesInfo });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const slice = createDuckdbSlice(set as any, get as any, undefined as any);
+    await slice.initialize();
+
+    expect(setCurrentConnection).toHaveBeenCalledTimes(1);
+    expect(setCurrentConnection).toHaveBeenCalledWith("prod");
+    expect(fetchDatabasesAndTablesInfo).not.toHaveBeenCalled();
+  });
+
+  it("falls back to fetchDatabasesAndTablesInfo when no ENV connection is configured", async () => {
+    window.env = {
+      DUCK_UI_EXTERNAL_CONNECTION_NAME: "",
+      DUCK_UI_EXTERNAL_HOST: "",
+      DUCK_UI_EXTERNAL_PORT: "",
+      DUCK_UI_EXTERNAL_USER: "",
+      DUCK_UI_EXTERNAL_PASS: "",
+      DUCK_UI_EXTERNAL_API_KEY: "",
+      DUCK_UI_EXTERNAL_DATABASE_NAME: "",
+      DUCK_UI_ALLOW_UNSIGNED_EXTENSIONS: false,
+    };
+
+    const setCurrentConnection = vi.fn().mockResolvedValue(undefined);
+    const fetchDatabasesAndTablesInfo = vi.fn().mockResolvedValue(undefined);
+
+    let state: Record<string, unknown> = { currentProfileId: null };
+    const set = (partial: unknown) => {
+      const next = typeof partial === "function" ? partial(state) : partial;
+      state = { ...state, ...next };
+    };
+    const get = () => ({ ...state, setCurrentConnection, fetchDatabasesAndTablesInfo });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const slice = createDuckdbSlice(set as any, get as any, undefined as any);
+    await slice.initialize();
+
+    expect(setCurrentConnection).not.toHaveBeenCalled();
+    expect(fetchDatabasesAndTablesInfo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/store/slices/duckdbSlice.ts
+++ b/src/store/slices/duckdbSlice.ts
@@ -156,8 +156,10 @@ export const createDuckdbSlice: StateCreator<
     }
 
     // An ENV-configured external server takes over as the active connection.
-    if (initialConnections[0].id !== WASM_CONNECTION_ID) {
-      await get().setCurrentConnection(initialConnections[0].id);
+    // The WASM provider is always pushed first, so index 0 is never it.
+    const envConnection = initialConnections.find((c) => c.environment === "ENV");
+    if (envConnection) {
+      await get().setCurrentConnection(envConnection.id);
     } else {
       await get().fetchDatabasesAndTablesInfo();
     }


### PR DESCRIPTION
## Summary
- `initialize()` decided whether to auto-connect the pre-configured `ENV` connection (from `DUCK_UI_EXTERNAL_HOST`/`PORT`/etc.) by checking `initialConnections[0]`, but the WASM provider is always pushed first — so that check could never be true and the branch was dead code, from the very first version of this slice.
- Effect: even with the `DUCK_UI_EXTERNAL_*` env vars set, the app always stayed on the in-browser WASM engine on boot; the ENV connection just sat in "Available Connections" unconnected until a user clicked Connect on it manually.
- Fix: look up the connection tagged `environment: "ENV"` directly instead of trusting index 0.

## Test plan
- [x] Added `src/store/slices/__tests__/duckdbSlice.envConnect.test.ts`, which calls the real `initialize()` with `window.env` populated and asserts `setCurrentConnection` is called with the ENV connection id (fails against the pre-fix code, passes against the fix).
- [x] Verified end-to-end against a real external DuckDB `httpserver` endpoint (X-API-Key auth) using the exact `toConnectionDefinition` → `openSession` → `introspect()` path `setCurrentConnection` takes — successfully retrieved the live catalog.
- [x] Ran the full test suite; no new failures.

Already running in production on our fork (`mskyttner/duck-ui`, currently `v1.2.1`).