### PR TITLE
fix(schema): wrap SUMMARIZE in a SELECT for column stats

### DIFF
--- a/src/store/slices/__tests__/schemaSlice.columnStatsQuery.test.ts
+++ b/src/store/slices/__tests__/schemaSlice.columnStatsQuery.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+
+/**
+ * Regression test for column stats being rejected by external endpoints that
+ * enforce a read-only statement allow-list keyed on the leading SQL keyword
+ * (SELECT, WITH, FROM, SHOW, DESCRIBE, EXPLAIN, PRAGMA). A bare `SUMMARIZE`
+ * isn't on that list, even though it's read-only, so `fetchTableColumnStats`
+ * must send it wrapped in a SELECT — which DuckDB plans as a genuine SELECT
+ * (aggregate + projection), not a special SUMMARIZE utility statement.
+ */
+
+const { runQuery } = vi.hoisted(() => ({
+  runQuery: vi.fn().mockResolvedValue({
+    columns: [],
+    columnTypes: [],
+    data: [],
+    rowCount: 0,
+  }),
+}));
+
+vi.mock("@/services/engine", () => ({
+  runQuery,
+  requireLocalDuckSession: vi.fn(),
+  catalogToDatabaseInfo: vi.fn(),
+}));
+
+import { createSchemaSlice } from "../schemaSlice";
+
+describe("fetchTableColumnStats query shape", () => {
+  it("wraps SUMMARIZE in a SELECT so a read-only allow-list accepts it", async () => {
+    const get = () => ({ currentSession: { id: "s" } }) as never;
+    const set = () => {};
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const slice = createSchemaSlice(set as any, get as any, undefined as any);
+    await slice.fetchTableColumnStats("analytics", "authors", "main");
+
+    expect(runQuery).toHaveBeenCalledTimes(1);
+    const [, sql] = runQuery.mock.calls[0];
+    expect(sql).toMatch(/^SELECT \* FROM \(SUMMARIZE /i);
+  });
+});

--- a/src/store/slices/schemaSlice.ts
+++ b/src/store/slices/schemaSlice.ts
@@ -52,7 +52,14 @@ export const createSchemaSlice: StateCreator<
   fetchTableColumnStats: async (databaseName, tableName, schema) => {
     const useBareName =
       databaseName === "main" || databaseName === "memory" || databaseName === ":memory:";
-    const query = `SUMMARIZE ${qualifyTable(useBareName ? undefined : databaseName, schema, tableName)}`;
+    // Wrapped in a SELECT rather than sent as a bare SUMMARIZE statement: some
+    // external endpoints (e.g. a reverse proxy enforcing read-only queries)
+    // allow-list by leading keyword, and SUMMARIZE isn't on it even though
+    // it's read-only. DuckDB plans this wrapped form as a genuine SELECT
+    // (aggregate + projection), not a special SUMMARIZE utility statement, so
+    // this isn't fooling a naive check — it equally satisfies one that
+    // inspects DuckDB's own statement type.
+    const query = `SELECT * FROM (SUMMARIZE ${qualifyTable(useBareName ? undefined : databaseName, schema, tableName)})`;
 
     try {
       const result = await runQuery(requireSession(get().currentSession), query, "column-stats");


### PR DESCRIPTION
## Summary
- `fetchTableColumnStats` sent a bare `SUMMARIZE <table>` statement to compute column stats for the schema explorer.
- Some external endpoints enforce read-only queries via a leading-keyword allow-list (`SELECT`, `WITH`, `FROM`, `SHOW`, `DESCRIBE`, `EXPLAIN`, `PRAGMA`). `SUMMARIZE` isn't on that list even though it's read-only, so opening a table in the schema explorer against such an endpoint gets a `403 Forbidden`.
- Fix: send `SELECT * FROM (SUMMARIZE ...)` instead. DuckDB plans this as a genuine `SELECT` (aggregate + projection) — confirmed via `EXPLAIN` locally, not a special `SUMMARIZE` utility statement — so it satisfies such a check without any server-side change.

## Test plan
- [x] Added `src/store/slices/__tests__/schemaSlice.columnStatsQuery.test.ts` asserting the query sent to the engine is the wrapped form (fails against the pre-fix bare `SUMMARIZE`, passes against the fix).
- [x] Verified end-to-end against a live external DuckDB `httpserver` endpoint that previously 403'd on this exact query — now returns `200` with full stats.
- [x] Ran the full test suite; no new failures.

## Note
Column stats fire on-demand (only when a table is expanded in the schema explorer, not on catalog load), but for very large tables the wrapped query can still take a while (measured ~48s on a 127M-row table) with no cancel affordance in the UI today. Out of scope here — noted for a follow-up.

Already running in production on our fork (`mskyttner/duck-ui`, currently `v1.2.1`).