### PR TITLE
fix(connections): add horizontal scrollbar to Available Connections table

### DIFF
--- a/src/components/connection/ConnectionsList.tsx
+++ b/src/components/connection/ConnectionsList.tsx
@@ -9,7 +9,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { ScrollArea } from "@/components/ui/scroll-area";
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -184,6 +184,10 @@ export function ConnectionsList({
           })}
         </TableBody>
       </Table>
+      {/* Without this, Radix's ScrollArea only enables the vertical axis —
+          a narrow container (e.g. the sidebar's Sheet) clips the table's
+          right-hand columns with no way to reach them. */}
+      <ScrollBar orientation="horizontal" />
     </ScrollArea>
   );
 }


### PR DESCRIPTION
## Summary
- Opening "Connections" from the sidebar (a Sheet capped at `sm:max-w-3xl`, non-resizable) clipped the table's right-hand columns, making the `Actions` column (Connect/status/info icon) unreachable for any connection.
- Root cause: Radix's `ScrollArea` sets `overflow-x: hidden` on its viewport unless a horizontal `ScrollAreaScrollbar` is mounted — confirmed directly in `@radix-ui/react-scroll-area`'s source. `ConnectionsList.tsx` only rendered the default vertical one, so content past the container's edge was genuinely clipped, not just missing a scrollbar affordance.
- This never showed up from the workspace-tab view of Connections, which happens to be wide enough that the table never overflows.

## Fix
Add `<ScrollBar orientation="horizontal" />` alongside the existing vertical one in `ConnectionsList.tsx`.

## Test plan
- [x] Ran a local dev server with the fix, opened Connections from the sidebar, confirmed the table now scrolls horizontally and the `Actions` column (Connected/info icon) is reachable — manually verified.
- [x] Checked the two other `ScrollArea` usages in the codebase; neither wraps a wide `<Table>`, so this was the only affected spot.
- [x] Lint (0 errors) and typecheck clean.

Already running in production on our fork (`mskyttner/duck-ui`, currently `v1.2.1`).